### PR TITLE
Update to v6.9.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+pkg_build_image_tag: main-rockylinux-8
+
+build_env_vars:
+  ANACONDA_ROCKET_GLIBC: '2.28'

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,7 +14,6 @@ cmake -LAH -G "Ninja"                               ^
     -DFORCE_LIMITED_API=OFF                         ^
     -DBUILD_TESTS=OFF                               ^
     -DPython_EXECUTABLE="%PYTHON%"                  ^
-    -DNUMPY_INCLUDE_DIR=%SP_DIR%\numpy\core\include ^
     .
 if errorlevel 1 exit 1
 
@@ -40,7 +39,6 @@ cmake -LAH -G "Ninja"                               ^
     -DCMAKE_BUILD_TYPE=Release                      ^
     -DPython_EXECUTABLE="%PYTHON%"                  ^
     -DFORCE_LIMITED_API=OFF                         ^
-    -DNUMPY_INCLUDE_DIR=%SP_DIR%\numpy\core\include ^
     .
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,7 +16,6 @@ cmake -LAH -G "Ninja" ${CMAKE_ARGS} \
   -DFORCE_LIMITED_API=OFF \
   -DBUILD_TESTS=OFF \
   -DPython_EXECUTABLE=${PYTHON} \
-  -DNUMPY_INCLUDE_DIR=${SP_DIR}/numpy/core/include \
   ..
 cmake --build . --target install
 popd
@@ -45,7 +44,6 @@ cmake -LAH -G "Ninja" ${CMAKE_ARGS} \
   -DFORCE_LIMITED_API=OFF \
   -DBUILD_TESTS=ON \
   -DPython_EXECUTABLE=${PYTHON} \
-  -DNUMPY_INCLUDE_DIR=${SP_DIR}/numpy/core/include \
   ..
 cmake --build . --target install
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,28 +1,35 @@
-# Qt 6.7 builds with XCode 11 and macOS 13 SDK but supports a minimum macOS version of 11. This requires matching
-# compiler versions as well for something around the same version that originally shipped with XCode 14. For us,
-# that is clang 14.
+# Qt 6.9 builds with XCode 15 and macOS 14 SDK but supports a minimum macOS version of 12.0. This requires matching
+# compiler versions as well for something around the same version that originally shipped with XCode 15. For us,
+# that is clang 17.
 
-# https://doc.qt.io/archives/qt-6.7/macos.html
+# https://doc.qt.io/qt-6/macos.html
 c_stdlib_version:  # [not linux]
-  - 11.1           # [osx]
-  - 2019.11        # [win]
+  - 12.0           # [osx]
+  - 2022.12        # [win]
 OSX_SDK_VER:
-  - 11.3
+  - 14.5
 
 # https://doc.qt.io/qt-6/windows.html
 c_compiler:    # [win]
-  - vs2019     # [win]
+  - vs2022     # [win]
 cxx_compiler:  # [win]
-  - vs2019     # [win]
+  - vs2022     # [win]
 
 # XCode 15.0 came with SDK 14.0 and clang 15
 # https://en.wikipedia.org/wiki/Xcode
 c_compiler_version:    # [osx]
-  - 14                 # [osx]
+  - 17                 # [osx]
 cxx_compiler_version:  # [osx]
-  - 14                 # [osx]
+  - 17                 # [osx]
+
+# Need at least a 12.0 host or else tests will fail.
+extra_labels_for_os:
+  osx-arm64: [ventura]
 
 # Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
 # 11.1 sysroot.
 CONDA_BUILD_SYSROOT:
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx and arm64]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX14.5.sdk  # [osx and arm64]
+
+qt:
+  - 6.9.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
-{% set name = "pyside6" %}
-{% set version = "6.7.3" %}
+{% set version = "6.9.2" %}
 {% set version_major_minor_match = '.'.join(version.split('.')[0:3]) %}
 
 package:
-  name: {{ name }}
+  name: pyside6
   version: {{ version }}
 
 source:
-  url: https://download.qt.io/official_releases/QtForPython/{{ name }}/PySide6-{{ version }}-src/pyside-setup-everywhere-src-{{ version }}.tar.xz
-  sha256: a4c414be013d5051a2d10a9a1151e686488a3172c08a57461ea04b0a0ab74e09
+  url: https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-{{ version }}-src/pyside-setup-everywhere-src-{{ version }}.tar.xz
+  sha256: 9ec087465342bdc9dbe492a30e58fdbbc5448655deacf5982a0fe7123f59222d
   patches:
     # https://bugreports.qt.io/browse/PYSIDE-1193
     - patches/pyi_osx.patch
@@ -21,10 +20,8 @@ source:
     - patches/add-opengl-header-path.patch  # [linux]
 
 build:
-  number: 1
-  # 6.8.x is required for python > 3.12
-  skip: true  # [py<39 or py>312]
-  skip: true  # [osx and x86_64]
+  number: 0
+  skip: true  # [py<39]
   entry_points:
     - pyside6-rcc = PySide6.scripts.pyside_tool:rcc
     - pyside6-uic = PySide6.scripts.pyside_tool:uic
@@ -36,17 +33,16 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
-    - patch        # [unix]
-    - msys2-patch  # [win]
   host:
     - python
     - setuptools
     - gtk2 2.24                            # [linux]
     - libxslt {{ libxslt }}
     - libxml2 {{ libxml2 }}
-    - mypy
-    # https://code.qt.io/cgit/pyside/pyside-setup.git/tree/requirements.txt?h=6.7.3
-    - numpy 1.26.3
+    # https://code.qt.io/cgit/pyside/pyside-setup.git/tree/requirements.txt?h=6.9.2
+    - mypy >=1.15.0
+    - numpy 2.0.2                          # [py<310]
+    - numpy 2.1.3                          # [py>39]
     - qtbase-devel {{ qt }}
     - qtdeclarative {{ qt }}
     - qtshadertools {{ qt }}
@@ -56,18 +52,15 @@ requirements:
     - qtwebengine {{ qt }}
     - qtwebsockets {{ qt }}
     - clangdev {{ cxx_compiler_version }}  # [osx]
-    - clangdev 14.0                        # [not osx]
+    - clangdev 17.0                        # [not osx]
+    - libclang
     - zstd {{ zstd }}
     - libgl-devel {{ libgl }}              # [linux]
     - libglx-devel {{ libglx }}            # [linux]
+    - libvulkan-headers {{ libvulkan }}    # [not osx]
+    - libvulkan-loader {{ libvulkan }}     # [not osx]
   run:
     - python
-    # Pulled in transitively through clangdev but is a weak export so we have to add it here.
-    - {{ pin_compatible("libclang13", max_pin="x.x") }}
-  run_constrained:
-    - qt5compat {{ version }}
-    - qtimageformats {{ version }}
-    - qttranslations {{ version }}
 
 test:
   imports:
@@ -119,6 +112,8 @@ about:
   dev_url: https://code.qt.io/cgit/pyside/pyside-setup.git
 
 extra:
+  skip-lints:
+    - has_run_test_and_commands
   recipe-maintainers:
     - jan-janssen
     - jschueller


### PR DESCRIPTION
pyside6 6.9.2

**Destination channel:** defaults

### Links

- [PKG-8699](https://anaconda.atlassian.net/browse/PKG-8699)
- [Upstream repository]()
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - AnacondaRecipes/qtwebengine-feedstock#5

### Explanation of changes:

- Update build environment to match that of Qt 6.9
- Remove extra numpy flags now that the numpy headers are in the v2 location and are found correctly


[PKG-8699]: https://anaconda.atlassian.net/browse/PKG-8699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ